### PR TITLE
Added notes related list + customized list view for applications

### DIFF
--- a/force-app/main/default/layouts/Application__c-Application Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Application__c-Application Layout.layout-meta.xml
@@ -140,6 +140,9 @@
         <relatedList>RelatedHistoryList</relatedList>
     </relatedLists>
     <relatedLists>
+        <relatedList>RelatedContentNoteList</relatedList>
+    </relatedLists>
+    <relatedLists>
         <relatedList>RelatedNoteList</relatedList>
     </relatedLists>
     <showEmailCheckbox>false</showEmailCheckbox>
@@ -148,7 +151,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h1F000004S7XD</masterLabel>
+        <masterLabel>00h54000004CeT3</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/objects/Application__c/listViews/All.listView-meta.xml
+++ b/force-app/main/default/objects/Application__c/listViews/All.listView-meta.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ListView xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>All</fullName>
+    <columns>NAME</columns>
+    <columns>Hiring_Company__c</columns>
+    <columns>Position__c</columns>
+    <columns>Date_Applied__c</columns>
     <filterScope>Everything</filterScope>
     <label>All</label>
 </ListView>


### PR DESCRIPTION
**This PR includes 2 quick fixes:**
 - Added Notes related list to the Application object 

<img width="1278" alt="Screen Shot 2021-06-03 at 6 54 42 PM" src="https://user-images.githubusercontent.com/63320271/120734412-ac074800-c49d-11eb-811f-8fea73ff282e.png">

 - Updated Application list view to show Hiring company, Position, and Date Applied 
<img width="1271" alt="Screen Shot 2021-06-03 at 6 53 50 PM" src="https://user-images.githubusercontent.com/63320271/120734350-9560f100-c49d-11eb-96de-eed8c9d607a2.png">